### PR TITLE
Change return type of HTTPClient.getString()

### DIFF
--- a/src/HTTPClient.cpp
+++ b/src/HTTPClient.cpp
@@ -34,7 +34,6 @@
 #include <WiFiClientSecure.h>
 #endif
 
-#include <StreamString.h>
 #include <base64.h>
 
 #include "HTTPClient.h"
@@ -919,7 +918,7 @@ int HTTPClient::writeToStream(Stream * stream)
  * return all payload as String (may need lot of ram or trigger out of memory!)
  * @return String
  */
-String HTTPClient::getString(void)
+StreamString HTTPClient::getString(void)
 {
     // _size can be -1 when Server sends no Content-Length header
     if(_size > 0 || _size == -1) {
@@ -934,7 +933,7 @@ String HTTPClient::getString(void)
         }
     }
 
-    return "";
+    return StreamString();
 }
 
 /**

--- a/src/HTTPClient.h
+++ b/src/HTTPClient.h
@@ -34,6 +34,7 @@
 #include <rpcWiFi.h>
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
+#include <StreamString.h>
 
 #define HTTPCLIENT_DEFAULT_TCP_TIMEOUT (5000)
 
@@ -211,7 +212,7 @@ public:
     WiFiClient& getStream(void);
     WiFiClient* getStreamPtr(void);
     int writeToStream(Stream* stream);
-    String getString(void);
+    StreamString getString(void);
 
     static String errorToString(int error);
 


### PR DESCRIPTION
Fix for not being able to HTTPS GET binary data.
The return type has been changed, but is still compatible with the previous one.