### PR TITLE
Chunking WiFi client writes in the HTTP client to handle large file sizes

### DIFF
--- a/src/HTTPClient.cpp
+++ b/src/HTTPClient.cpp
@@ -578,11 +578,9 @@ int HTTPClient::sendRequest(const char * type, uint8_t * payload, size_t size)
 
         // send Payload if needed
         if(payload && size > 0) {
-            // Send in chunks of 1024 bytes
-            const size_t chunk_size = 1024;
-            
-            for (size_t pos = 0; pos < size; pos += chunk_size) {
-                size_t to_write = min(1024, size - pos);
+            // Send in chunks of HTTP_TCP_BUFFER_SIZE bytes            
+            for (size_t pos = 0; pos < size; pos += HTTP_TCP_BUFFER_SIZE) {
+                size_t to_write = min(HTTP_TCP_BUFFER_SIZE, size - pos);
                 if(_client->write(&payload[pos], to_write) != to_write) {
                     return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
                 }

--- a/src/HTTPClient.cpp
+++ b/src/HTTPClient.cpp
@@ -578,8 +578,14 @@ int HTTPClient::sendRequest(const char * type, uint8_t * payload, size_t size)
 
         // send Payload if needed
         if(payload && size > 0) {
-            if(_client->write(&payload[0], size) != size) {
-                return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
+            // Send in chunks of 1024 bytes
+            const size_t chunk_size = 1024;
+            
+            for (size_t pos = 0; pos < size; pos += chunk_size) {
+                size_t to_write = min(1024, size - pos);
+                if(_client->write(&payload[pos], to_write) != to_write) {
+                    return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
+                }
             }
         }
 


### PR DESCRIPTION
This code changes the way data is written to the WiFIClient. Instead of sending the data in one block, it is sent in chunks of 1024 bytes.

This fixes #19.