### PR TITLE
Flush RX buffer instead of the socket

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -481,9 +481,9 @@ void WiFiClient::flush() {
     }
     while(a){
         toRead = (a>WIFI_CLIENT_FLUSH_BUFFER_SIZE)?WIFI_CLIENT_FLUSH_BUFFER_SIZE:a;
-        res = recv(fd(), buf, toRead, MSG_DONTWAIT);
+        res = _rxBuffer->read(buf, toRead);
         if(res < 0) {
-            log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
+            log_e("Read failed even though still data available");
             stop();
             break;
         }


### PR DESCRIPTION
While investigating hangups upon disconnecting a PubSubClient instance, bound to this WiFiClient implementation, @reifab traced the issue down to `PubSubClient::disconnect()` getting stuck, whenever it invoked `WiFiClient::flush()` in your implementation. Further investigation showed, that this issue appeared whenever some data was left in `WiFiClient::_rxBuffer` which could occur if a flush was requested while not all data has been received yet. 

Looking deeper into the code, I got the impression, that the whole flush method should rather read by invoking `_rxBuffer->read()` instead of talking to the socket directly through `recv`, as reading the socket appears to be delegated to the `WiFiClientRxBuffer` in general.

What we didn't think through completely is, whether we should loop here until `WiFiClientRxBuffer::available` reports `0` bytes instead of just fetching whatever is in the buffer so far. To my understanding, looping until `available` returns zero would also cause the socket to be drained.

Any opinions from the maintainers regarding that approach?